### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,5 @@ FDCalendar is a custom calendar control which includes world and chinese calenda
     [self.view addSubview:calendar];
 ```
 
-#License
+# License
   MIT


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
